### PR TITLE
Bug fixes

### DIFF
--- a/qontrol/cost.py
+++ b/qontrol/cost.py
@@ -6,7 +6,7 @@ import jax.tree_util as jtu
 from jax.nn import relu
 from dynamiqs import asqarray, isket, QArray, QArrayLike, TimeQArray
 from dynamiqs.result import PropagatorResult, SolveResult
-from dynamiqs.time_qarray import SummedTimeQArray
+from dynamiqs.time_qarray import SummedTimeQArray, ConstantTimeQArray
 from jax import Array, vmap
 
 
@@ -433,8 +433,8 @@ class ControlCost(Cost):
         self, result: SolveResult, H: TimeQArray, func: callable
     ) -> Array:
         def _evaluate_at_tsave(_H: TimeQArray) -> Array:
-            if hasattr(_H, 'prefactor'):
-                return jnp.sum(func(vmap(_H.prefactor)(result.tsave)))
+            if not isinstance(_H, ConstantTimeQArray):
+                return jnp.sum(func(_H.prefactor(result.tsave)))
             return jnp.array(0.0)
 
         if isinstance(H, SummedTimeQArray):

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -221,8 +221,7 @@ def loss(
 ) -> [float, Array]:
     result, H = model(parameters, method, gradient, dq_options)
     cost_values, terminate = zip(*costs(result, H, parameters), strict=True)
-    total_cost = jax.tree.reduce(jnp.add, cost_values)
-    total_cost = jnp.log(jnp.sum(jnp.asarray(total_cost)))
+    total_cost = jnp.log(jax.tree.reduce(jnp.add, cost_values))
     expects = result.expects if hasattr(result, 'expects') else None
     return total_cost, (total_cost, cost_values, terminate, expects)
 

--- a/qontrol/optimize.py
+++ b/qontrol/optimize.py
@@ -6,7 +6,6 @@ from functools import partial
 import dynamiqs as dq
 import jax
 import jax.numpy as jnp
-import numpy as np
 import optax
 from dynamiqs.gradient import Gradient
 from dynamiqs.method import Method, Tsit5
@@ -140,7 +139,7 @@ def optimize(
             parameters, grads, opt_state, aux = jax.block_until_ready(
                 step(parameters, costs, model, opt_state, method, gradient, dq_options)
             )
-            elapsed_time = np.around(time.time() - epoch_start_time, decimals=3)
+            elapsed_time = jnp.round(time.time() - epoch_start_time, decimals=3)
             total_cost, cost_values, terminate_for_cost, expects = aux
             cost_values_over_epochs.append(cost_values)
             epoch_times.append(elapsed_time)
@@ -196,14 +195,16 @@ def optimize(
             cost_values_over_epochs,
             len(cost_values_over_epochs) - 1,
         )
+
+    epoch_times = jnp.array(epoch_times)
     if not opt_options['ignore_termination']:
         print(TERMINATION_MESSAGES[termination_key])
     print(
         f'optimization terminated after {epoch} epochs; \n'
         f'average epoch time (excluding jit) of '
-        f'{np.around(np.mean(epoch_times[1:]), decimals=5)} s; \n'
-        f'max epoch time of {np.max(epoch_times[1:])} s; \n'
-        f'min epoch time of {np.min(epoch_times[1:])} s'
+        f'{jnp.round(jnp.mean(epoch_times[1:]), decimals=5)} s; \n'
+        f'max epoch time of {jnp.max(epoch_times[1:])} s; \n'
+        f'min epoch time of {jnp.min(epoch_times[1:])} s'
     )
     if opt_options['verbose'] and filepath is not None:
         print(f'results saved to {filepath}')
@@ -255,7 +256,7 @@ def _terminate_early(
     if dg < opt_options['gtol']:
         termination_key = 1
     # ftol
-    dF = np.abs(total_cost - prev_total_cost)
+    dF = jnp.abs(total_cost - prev_total_cost)
     if dF < opt_options['ftol'] * total_cost:
         termination_key = 2
     if dx < opt_options['xtol'] * (opt_options['xtol'] + dx):
@@ -270,5 +271,5 @@ def _terminate_early(
 
 def _norm(x: Array) -> Array:
     if x.shape == ():
-        return np.abs(x)
-    return np.linalg.norm(x, ord=np.inf)
+        return jnp.abs(x)
+    return jnp.max(jnp.abs(x))

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -42,7 +42,7 @@ def get_controls(H: TimeQArray, tsave: np.ndarray) -> list[np.ndarray]:
     """Extract the Hamiltonian prefactors at the supplied times."""
 
     def evaluate_at_tsave(_H: TimeQArray) -> np.ndarray:
-        if hasattr(_H, 'prefactor'):
+        if not isinstance(_H, ConstantTimeQArray):
             return np.asarray(jax.vmap(_H.prefactor)(tsave))
         return np.zeros_like(tsave)
 

--- a/qontrol/plot.py
+++ b/qontrol/plot.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import jax
 import matplotlib.pyplot as plt
 import numpy as np
 from dynamiqs.time_qarray import ConstantTimeQArray, SummedTimeQArray, TimeQArray
@@ -43,7 +42,7 @@ def get_controls(H: TimeQArray, tsave: np.ndarray) -> list[np.ndarray]:
 
     def evaluate_at_tsave(_H: TimeQArray) -> np.ndarray:
         if not isinstance(_H, ConstantTimeQArray):
-            return np.asarray(jax.vmap(_H.prefactor)(tsave))
+            return _H.prefactor(tsave)
         return np.zeros_like(tsave)
 
     controls = []
@@ -180,7 +179,7 @@ def custom_plotter(plotting_functions: list[Callable]) -> Plotter:
                 H_c = dq.pwc(tsave, control, H1s[idx])
                 ax.plot(
                     finer_tsave,
-                    np.real(jax.vmap(H_c.prefactor)(finer_tsave)) / 2 / np.pi,
+                    np.real(H_c.prefactor(finer_tsave)) / 2 / np.pi,
                     label=H1_labels[idx],
                 )
             ax.legend(loc='lower right', framealpha=0.0)


### PR DESCRIPTION
Bug fixes: 
- The control drive area is computed as a Riemann sum; however, the `dt` factor was missing. Fixed this bug.
- Fixed a bug caused by [dynamiqs #974](https://github.com/dynamiqs/dynamiqs/pull/974). The new `TimeQArray.prefactor()` method in the parent class now adds a prefactor to all children, including `ConstantTimeQArray`. Previously, `qontrol` checked for the presence or absence of a prefactor attribute, but now I check if a Hamiltonian is a `ConstantTimeQArray`.

Optimization: 
- Avoid computing propagator dim at every call
- Minimize numpy dependence
- Remove redundant line in loss()